### PR TITLE
Update txn_builder_governance.ts

### DIFF
--- a/packages/jellyfish-transaction-builder/src/txn/txn_builder_governance.ts
+++ b/packages/jellyfish-transaction-builder/src/txn/txn_builder_governance.ts
@@ -45,13 +45,13 @@ export class TxnBuilderGovernance extends P2WPKHTxnBuilder {
     }
     let creationFee = new BigNumber('5')
     if (this.network.name === 'mainnet') {
-      creationFee = new BigNumber('100')
+      creationFee = new BigNumber('50')
     }
     if (this.network.name === 'testnet') {
       creationFee = new BigNumber('50')
     }
     if (createVoc.options === 1) {
-      creationFee = new BigNumber('10000')
+      creationFee = new BigNumber('5000')
     }
     return await this.createDeFiTx(
       OP_CODES.OP_DEFI_TX_CREATE_VOC(createVoc),


### PR DESCRIPTION
currently, sending a DFIP via jellyfishSDK fails, cause it sets the wrong fees. 
Fixes https://github.com/BirthdayResearch/defichain-wallet/issues/3946
